### PR TITLE
add winamp default shortcuts

### DIFF
--- a/src/mainwindow/maindisplay.cpp
+++ b/src/mainwindow/maindisplay.cpp
@@ -40,6 +40,7 @@
 
 #include <QFileDialog>
 #include <QSettings>
+#include <QShortcut>
 #include <QDebug>
 
 MainDisplay::MainDisplay (MainWindow *parent) : SkinDisplay(parent)
@@ -59,6 +60,7 @@ MainDisplay::MainDisplay (MainWindow *parent) : SkinDisplay(parent)
 	m_mw = parent;
 
 	SetupPushButtons (client);
+	SetupShortcuts (client);
 	SetupToggleButtons ();
 
 	m_text = new TextScroller (this, 154, 12, "main");
@@ -334,6 +336,31 @@ MainDisplay::SetupPushButtons (const XClient* client)
 	m_eject->resize (skin->getSize (Skin::BUTTON_MW_EJECT));
 	m_eject->move (skin->getPos (Skin::BUTTON_MW_EJECT));
 	connect (m_eject, SIGNAL(clicked()), this, SLOT(fileOpen()));
+
+}
+
+void
+MainDisplay::SetupShortcuts (const XClient* client)
+{
+	/* Normal buttons */
+	QShortcut *shortcut_prev = new QShortcut(QKeySequence("z"), this);
+	connect (shortcut_prev, SIGNAL(activated()), client->xplayback (), SLOT(prev ()));
+
+	QShortcut *shortcut_play = new QShortcut(QKeySequence("x"), this);
+	connect (shortcut_play, SIGNAL(activated()), client->xplayback (), SLOT(play ()));
+
+
+	QShortcut *shortcut_pause = new QShortcut(QKeySequence("c"), this);
+	connect (shortcut_pause, SIGNAL(activated()), client->xplayback (), SLOT(toggle_pause ()));
+
+	QShortcut *shortcut_stop = new QShortcut(QKeySequence("v"), this);
+	connect (shortcut_stop, SIGNAL(activated()), client->xplayback (), SLOT(stop ()));
+
+	QShortcut *shortcut_next = new QShortcut(QKeySequence("b"), this);
+	connect (shortcut_next, SIGNAL(activated()), client->xplayback (), SLOT(next ()));
+
+	QShortcut *shortcut_eject = new QShortcut(QKeySequence("n"), this);
+	connect (shortcut_eject, SIGNAL(activated()), this, SLOT(fileOpen()));
 
 }
 

--- a/src/mainwindow/maindisplay.cpp
+++ b/src/mainwindow/maindisplay.cpp
@@ -343,24 +343,23 @@ void
 MainDisplay::SetupShortcuts (const XClient* client)
 {
 	/* Normal buttons */
-	QShortcut *shortcut_prev = new QShortcut(QKeySequence("z"), this);
-	connect (shortcut_prev, SIGNAL(activated()), client->xplayback (), SLOT(prev ()));
+	QShortcut *shortcut_prev = new QShortcut (QKeySequence ("z"), this);
+	connect (shortcut_prev, SIGNAL (activated ()), client->xplayback (), SLOT (prev ()));
 
-	QShortcut *shortcut_play = new QShortcut(QKeySequence("x"), this);
-	connect (shortcut_play, SIGNAL(activated()), client->xplayback (), SLOT(play ()));
+	QShortcut *shortcut_play = new QShortcut (QKeySequence ("x"), this);
+	connect (shortcut_play, SIGNAL (activated ()), client->xplayback (), SLOT (play ()));
 
+	QShortcut *shortcut_pause = new QShortcut (QKeySequence ("c"), this);
+	connect (shortcut_pause, SIGNAL (activated ()), client->xplayback (), SLOT (toggle_pause ()));
 
-	QShortcut *shortcut_pause = new QShortcut(QKeySequence("c"), this);
-	connect (shortcut_pause, SIGNAL(activated()), client->xplayback (), SLOT(toggle_pause ()));
+	QShortcut *shortcut_stop = new QShortcut (QKeySequence ("v"), this);
+	connect (shortcut_stop, SIGNAL (activated ()), client->xplayback (), SLOT (stop ()));
 
-	QShortcut *shortcut_stop = new QShortcut(QKeySequence("v"), this);
-	connect (shortcut_stop, SIGNAL(activated()), client->xplayback (), SLOT(stop ()));
+	QShortcut *shortcut_next = new QShortcut (QKeySequence ("b"), this);
+	connect (shortcut_next, SIGNAL (activated ()), client->xplayback (), SLOT (next ()));
 
-	QShortcut *shortcut_next = new QShortcut(QKeySequence("b"), this);
-	connect (shortcut_next, SIGNAL(activated()), client->xplayback (), SLOT(next ()));
-
-	QShortcut *shortcut_eject = new QShortcut(QKeySequence("n"), this);
-	connect (shortcut_eject, SIGNAL(activated()), this, SLOT(fileOpen()));
+	QShortcut *shortcut_eject = new QShortcut (QKeySequence ("n"), this);
+	connect (shortcut_eject, SIGNAL (activated ()), this, SLOT (fileOpen ()));
 
 }
 

--- a/src/mainwindow/maindisplay.h
+++ b/src/mainwindow/maindisplay.h
@@ -85,6 +85,7 @@ class MainDisplay : public SkinDisplay
 
 	protected:
 		void SetupPushButtons (const XClient *);
+		void SetupShortcuts (const XClient *);
 		void SetupToggleButtons (void);
 
 		PixmapButton *m_prev;

--- a/src/playlist/playlistwidget.cpp
+++ b/src/playlist/playlistwidget.cpp
@@ -43,6 +43,7 @@
 #include <QFileDialog>
 #include <QPainter>
 #include <QUrl>
+#include <QShortcut>
 
 /*
  *
@@ -236,6 +237,22 @@ PlaylistWidget::PlaylistWidget (PlaylistWindow *parent) : QWidget (parent)
 	         App, SLOT (toggleTime()));
 	connect (parent, SIGNAL (setDisplayTime (int)),
 	         m_controls, SIGNAL (setDisplayTime (int)));
+
+QShortcut *shortcut_prev = new QShortcut(QKeySequence("z"), this);
+	connect (shortcut_prev, SIGNAL(activated()), client->xplayback (), SLOT(prev ()));
+
+	QShortcut *shortcut_play = new QShortcut(QKeySequence("x"), this);
+	connect (shortcut_play, SIGNAL(activated()), client->xplayback (), SLOT(play ()));
+
+
+	QShortcut *shortcut_pause = new QShortcut(QKeySequence("c"), this);
+	connect (shortcut_pause, SIGNAL(activated()), client->xplayback (), SLOT(toggle_pause ()));
+
+	QShortcut *shortcut_stop = new QShortcut(QKeySequence("v"), this);
+	connect (shortcut_stop, SIGNAL(activated()), client->xplayback (), SLOT(stop ()));
+
+	QShortcut *shortcut_next = new QShortcut(QKeySequence("b"), this);
+	connect (shortcut_next, SIGNAL(activated()), client->xplayback (), SLOT(next ()));
 
 
 	connect (App->client ()->active_playlist (),

--- a/src/playlist/playlistwidget.cpp
+++ b/src/playlist/playlistwidget.cpp
@@ -238,21 +238,20 @@ PlaylistWidget::PlaylistWidget (PlaylistWindow *parent) : QWidget (parent)
 	connect (parent, SIGNAL (setDisplayTime (int)),
 	         m_controls, SIGNAL (setDisplayTime (int)));
 
-QShortcut *shortcut_prev = new QShortcut(QKeySequence("z"), this);
-	connect (shortcut_prev, SIGNAL(activated()), client->xplayback (), SLOT(prev ()));
+	QShortcut *shortcut_prev = new QShortcut (QKeySequence ("z"), this);
+	connect (shortcut_prev, SIGNAL (activated ()), client->xplayback (), SLOT (prev ()));
 
-	QShortcut *shortcut_play = new QShortcut(QKeySequence("x"), this);
-	connect (shortcut_play, SIGNAL(activated()), client->xplayback (), SLOT(play ()));
+	QShortcut *shortcut_play = new QShortcut (QKeySequence ("x"), this);
+	connect (shortcut_play, SIGNAL (activated ()), client->xplayback (), SLOT (play ()));
 
+	QShortcut *shortcut_pause = new QShortcut (QKeySequence ("c"), this);
+	connect (shortcut_pause, SIGNAL (activated ()), client->xplayback (), SLOT (toggle_pause ()));
 
-	QShortcut *shortcut_pause = new QShortcut(QKeySequence("c"), this);
-	connect (shortcut_pause, SIGNAL(activated()), client->xplayback (), SLOT(toggle_pause ()));
+	QShortcut *shortcut_stop = new QShortcut (QKeySequence ("v"), this);
+	connect (shortcut_stop, SIGNAL (activated ()), client->xplayback (), SLOT (stop ()));
 
-	QShortcut *shortcut_stop = new QShortcut(QKeySequence("v"), this);
-	connect (shortcut_stop, SIGNAL(activated()), client->xplayback (), SLOT(stop ()));
-
-	QShortcut *shortcut_next = new QShortcut(QKeySequence("b"), this);
-	connect (shortcut_next, SIGNAL(activated()), client->xplayback (), SLOT(next ()));
+	QShortcut *shortcut_next = new QShortcut (QKeySequence ("b"), this);
+	connect (shortcut_next, SIGNAL (activated ()), client->xplayback (), SLOT (next ()));
 
 
 	connect (App->client ()->active_playlist (),


### PR DESCRIPTION
Hello,

I have added winamp default shortcuts. 
- z : previous track
- x : play
- c : pause
- v : stop
- b : next track
- n : open

I'm having problem adding media button, I have tried those constant with no luck :
      Key_MediaTogglePlayPause
      Key_MediaPause
      Key_MediaPlay
      Key_MediaStop
      Key_Play
      Key_Stop

Is there someone who can help me ?

I'm using ubuntu 20.04.

thank you.