### PR TITLE
QT5:  Don't crash on volume change.

### DIFF
--- a/backend_xmmsclient++/xplayback.cpp
+++ b/backend_xmmsclient++/xplayback.cpp
@@ -160,6 +160,7 @@ XPlayback::volume_changed (const Xmms::Dict &volDict)
 		volumes.insert (key, levels.value (key).toInt());
 	}
 	emit volumeChanged (volumes);
+	return true;
 }
 
 


### PR DESCRIPTION
Callback was missing return true;